### PR TITLE
bugfix: add coreutils

### DIFF
--- a/scanner.yml
+++ b/scanner.yml
@@ -2,7 +2,7 @@
   image: "docker:20.10.23"
 
   before_script:
-    - apk add --no-cache bash curl git openssh-client
+    - apk add --no-cache bash curl git openssh-client coreutils
     - |
         boost_init_config () {
           boost_log_info () {


### PR DESCRIPTION
# without coreutils

```

docker run -it docker:20.10.23 sh
/ # sha256sum --check asdf
sha256sum: unrecognized option: check
BusyBox v1.35.0 (2022-11-19 10:13:10 UTC) multi-call binary.

Usage: sha256sum [-c[sw]] [FILE]...

Print or check SHA256 checksums

	-c	Check sums against list in FILEs
	-s	Don't output anything, status code shows success
	-w	Warn about improperly formatted checksum lines
```

# with coreutils

```
docker run -it docker:20.10.23 sh
/ # apk add coreutils
(1/5) Installing libacl (2.3.1-r1)
(2/5) Installing libattr (2.5.1-r2)
(3/5) Installing skalibs (2.12.0.1-r0)
(4/5) Installing utmps-libs (0.1.2.0-r1)
(5/5) Installing coreutils (9.1-r0)
Executing busybox-1.35.0-r29.trigger
OK: 15 MiB in 28 packages
/ # sha256sum --check asdf.txt
sha256sum: asdf.txt: No such file or directory
```