### PR TITLE
BST-11897: add optional docker proxy support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,4 +6,4 @@ scan:
   extends:
     - .boost_scan
   variables:
-    BOOST_SCANNER_REGISTRY_MODULE: "boostsecurityio/native-scanner"
+    BOOST_SCANNER_REGISTRY_MODULE: "boostsecurityio/scanner"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ The Boost Security API token secret.
 **NOTE**: We recommend you not put the API token directly in your pipeline
 file. Instead, it should be exposed via a **secret**.
 
+### `CI_DOCKER_PROXY` (Optional, string)
+
+Enable or disable the gitlab dependency proxy for docker images.
+May be set to one of the following values:
+- disabled: disable the proxy (default)
+- group: enable the group proxy
+- direct: enable the direct proxy
+
 ### `BOOST_CLI_VERSION` (Optional, string)
 
 Overrides the cli version to download when performing scans. If undefined,

--- a/scanner.yml
+++ b/scanner.yml
@@ -49,17 +49,16 @@
         fi
       done
     - |
-      export CI_DOCKER_PROXY="disabled"
-
-      if [ -n "${CI_DEPENDENCY_PROXY_SERVER:-}" ]; then
-        docker login -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
-
-        if docker pull "${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX:-}/scratch" &> /dev/null; then
-          export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}"
-        elif docker pull "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-}/scratch" &> /dev/unll; then
-          export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
-        fi
+      if [ "${CI_DOCKER_PROXY:-}" == "group" ]; then
+        export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}"
+      elif [ "${CI_DOCKER_PROXY:-}" == "direct" ]; then
+        export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
       fi
+
+      if [ -n "${CI_DOCKER_PROXY:-}" ]; then
+        echo "${CI_DEPENDENCY_PROXY_PASSWORD}" | docker login "${CI_DEPENDENCY_PROXY_SERVER}" -u "${CI_DEPENDENCY_PROXY_USER}" --password-stdin
+      fi
+
 
 .boost_dind:
   services:

--- a/scanner.yml
+++ b/scanner.yml
@@ -48,6 +48,18 @@
           break
         fi
       done
+    - |
+      export CI_DOCKER_PROXY="disabled"
+
+      if [ -n "${CI_DEPENDENCY_PROXY_SERVER:-}" ]; then
+        docker login -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
+
+        if docker pull "${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX:-}/scratch" &> /dev/null; then
+          export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}"
+        elif docker pull "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-}/scratch" &> /dev/unll; then
+          export CI_DOCKER_PROXY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
+        fi
+      fi
 
 .boost_dind:
   services:


### PR DESCRIPTION
support for the `CI_DOCKER_PROXY` environment variable is added
which adds support for the gitlab docker proxy.